### PR TITLE
Fix ResetSelectableHighlight resets button to normal when it's actually disabled

### DIFF
--- a/Runtime/Scripts/Utilities/ResetSelectableHighlight.cs
+++ b/Runtime/Scripts/Utilities/ResetSelectableHighlight.cs
@@ -1,29 +1,24 @@
 /// Credit SimonDarksideJ
 
+using UnityEngine.EventSystems;
+
 namespace UnityEngine.UI.Extensions
 {
-    /*
-    Handy Selectable script to un-highlight a selectable component in Unity (e.g. a Button) when the user moves away from it, EVEN IF the user has holding a button on it.
-
-    Resolves the situation where Unity UI Components remain in a highlighted state even after the pointer has moved away (e.g. user holding a button, mouse, pointer down).
-    Now whenever the cursor leaves the component, it will force the UI component to revert to un-highlighted.
-    */
-
-    using UnityEngine;
-    using UnityEngine.EventSystems;
-    using UnityEngine.UI;
-
+    /// <summary>
+    /// Handy Selectable script to un-highlight a selectable component in Unity (e.g. a Button) when the user moves away from it, EVEN IF the user has holding a button on it.
+    /// Resolves the situation where Unity UI Components remain in a highlighted state even after the pointer has moved away (e.g. user holding a button, mouse, pointer down).
+    /// Now whenever the cursor leaves the component, it will force the UI component to revert to un-highlighted.
+    /// </summary>
     [AddComponentMenu("UI/Extensions/ResetSelectableHighlight", 31)]
     [RequireComponent(typeof(Selectable))]
     public class ResetSelectableHighlight : MonoBehaviour, IPointerExitHandler
     {
         [SerializeField]
-        private Selectable attachedSelectable;
+        private Selectable attachedSelectable = null;
 
-        // Start is called before the first frame update
-        void Awake()
+        private void Awake()
         {
-            if (!attachedSelectable)
+            if (attachedSelectable == null || !attachedSelectable)
             {
                 attachedSelectable = GetComponent<Selectable>();
             }
@@ -31,6 +26,11 @@ namespace UnityEngine.UI.Extensions
 
         public void OnPointerExit(PointerEventData eventData)
         {
+            if (!attachedSelectable.interactable)
+            {
+                return;
+            }
+
             attachedSelectable.targetGraphic.CrossFadeColor(attachedSelectable.colors.normalColor, 0f, true, true);
         }
     }


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview

- Cleaned up the component and applied formatting
- Fixed issue that the component will reset a disabled button to normal coloring when it should stay disabled visually