### PR TITLE
Linerenderer points

### DIFF
--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -419,7 +419,7 @@ namespace UnityEngine.UI.Extensions
             {
                 return Segments[segmentIndex - 1][index - 1];
             }
-            else if (Segments.Count > 0)
+            else if (Segments?.Count > 0)
             {
                 var segmentIndexCount = 0;
                 var indexCount = index;

--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -452,7 +452,7 @@ namespace UnityEngine.UI.Extensions
 		/// <param name="p1">Required Control point 2</param>
 		/// <param name="p1">Required End point</param>
         /// <returns>Vector2 position of point on curve at t percentage between p1 and p4</returns>
-		private Vector2 CalculatePointOnCurve(float t, Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4)
+		public Vector2 CalculatePointOnCurve(float t, Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4)
         {
             var t2 = t * t;
             var t3 = t2 * t;

--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -443,6 +443,29 @@ namespace UnityEngine.UI.Extensions
             }
         }
 
+		/// <summary>
+        /// Calculates the position of a point on the curve, given t (0-1), start point, control points and end point.
+        /// </summary>
+        /// <param name="t">Required Percentage between start and end point, in the range 0 to 1</param>
+		/// <param name="p1">Required Starting point</param>
+		/// <param name="p1">Required Control point 1</param>
+		/// <param name="p1">Required Control point 2</param>
+		/// <param name="p1">Required End point</param>
+        /// <returns>Vector2 position of point on curve at t percentage between p1 and p4</returns>
+		private Vector2 CalculatePointOnCurve(float t, Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4)
+        {
+            var t2 = t * t;
+            var t3 = t2 * t;
+
+            var x = p1.x + (-p1.x * 3 + t * (3 * p1.x - p1.x * t)) * t + (3 * p2.x + t * (-6 * p2.x + p2.x * 3 * t)) * t +
+                    (p3.x * 3 - p3.x * 3 * t) * t2 + p4.x * t3;
+            
+            var y = p1.y + (-p1.y * 3 + t * (3 * p1.y - p1.y * t)) * t + (3 * p2.y + t * (-6 * p2.y + p2.y * 3 * t)) * t +
+                    (p3.y * 3 - p3.y * 3 * t) * t2 + p4.y * t3;
+
+            return new Vector2(x, y);
+        }
+
         /// <summary>
         /// Get the Vector2 position of a line within a specific segment
         /// </summary>


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview

- Added UILineRenderer functionality to calculate points on the bezier curve, given a percentage, start/end points and control points.
- Added null check for Segments to avoid throwing NullReferenceException on GetPosition calls.

## Changes
- Vector2 CalculatePointOnCurve(float t, Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4) added to UILineRenderer.cs

## Breaking Changes
No breaking changes.

## Testing status
* No tests have been added.

### Manual testing status
```
var stepSize = 1f / pointsToPlot;
            
for (int i = 0; i < pointsToPlot; i++)
{
    var position = _lineRenderer.CalculatePointOnCurve(i * stepSize, _lineRenderer.Points[0],
        _lineRenderer.Points[1], _lineRenderer.Points[2], _lineRenderer.Points[3]);
    PlotPoint(position);
}
```
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
