### PR TITLE
Update UILineRenderer.cs

### DIFF
--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -287,7 +287,7 @@ namespace UnityEngine.UI.Extensions
 				PopulateMesh (vh, m_points);
 
 			}
-			else if (m_segments != null && m_segments.Count > 0) {
+			if (m_segments != null && m_segments.Count > 0) {
 				GeneratedUVs ();
 				vh.Clear ();
 


### PR DESCRIPTION
There is no need to draw either points or segments. Both should be drawn.

# Unity UI Extensions - Pull Request

## Overview
Without my proposed change, segments will not be drawn if there are points in the lineRenderer

## Changes
Just remove the "else" clause from the PopulateMesh

## Breaking Changes
No

- Breaks

## Related Submodule Changes

<!--  Include any submodule related Pull Request links here -->
- URL

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.
* Includes unit tests.
* Includes performance tests.
* Includes integration tests.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
