### PR TITLE
Add using lengthScale to UIParticleSystem

### DIFF
--- a/Runtime/Scripts/Effects/UIParticleSystem.cs
+++ b/Runtime/Scripts/Effects/UIParticleSystem.cs
@@ -29,7 +29,6 @@ namespace UnityEngine.UI.Extensions
         private Vector2 textureSheetAnimationFrameSize;
         private ParticleSystemRenderer pRenderer;
         private bool isInitialised = false;
-        private float _lengthScale;
 
         private Material currentMaterial;
 
@@ -96,7 +95,6 @@ namespace UnityEngine.UI.Extensions
                 if (pRenderer != null)
                     pRenderer.enabled = false;
                 
-                _lengthScale = pRenderer.lengthScale;
                 if (material == null)
                 {
                     var foundShader = ShaderLibrary.GetShaderInstance("UI Extensions/Particles/Additive");
@@ -285,8 +283,8 @@ namespace UnityEngine.UI.Extensions
 
                 
                 float rotation = -particle.rotation * Mathf.Deg2Rad;
-                var lengthScale = _lengthScale;
-                if (_useLengthScale) // this flag is mostly to secure old behaviour, it probably can be replaced with _lengthScale != 1
+                var lengthScale = pRenderer.lengthScale;
+                if (_useLengthScale)
                 {
                     // rotate towards velocity
                     var normalizedVelocity = particle.velocity.normalized;

--- a/Runtime/Scripts/Effects/UIParticleSystem.cs
+++ b/Runtime/Scripts/Effects/UIParticleSystem.cs
@@ -16,6 +16,9 @@ namespace UnityEngine.UI.Extensions
         [Tooltip("Enables 3d rotation for the particles")]
         public bool use3dRotation = false;
 
+        [Tooltip("Enables using Renderer.lengthScale parameter")]
+        public bool _useLengthScale = false;
+        
         private Transform _transform;
         private ParticleSystem pSystem;
         private ParticleSystem.Particle[] particles;
@@ -26,6 +29,7 @@ namespace UnityEngine.UI.Extensions
         private Vector2 textureSheetAnimationFrameSize;
         private ParticleSystemRenderer pRenderer;
         private bool isInitialised = false;
+        private float _lengthScale;
 
         private Material currentMaterial;
 
@@ -91,7 +95,8 @@ namespace UnityEngine.UI.Extensions
                 pRenderer = pSystem.GetComponent<ParticleSystemRenderer>();
                 if (pRenderer != null)
                     pRenderer.enabled = false;
-
+                
+                _lengthScale = pRenderer.lengthScale;
                 if (material == null)
                 {
                     var foundShader = ShaderLibrary.GetShaderInstance("UI Extensions/Particles/Additive");
@@ -183,8 +188,6 @@ namespace UnityEngine.UI.Extensions
 #else
                 Vector2 position = (pSystem.simulationSpace == ParticleSystemSimulationSpace.Local ? particle.position : _transform.InverseTransformPoint(particle.position));
 #endif
-                float rotation = -particle.rotation * Mathf.Deg2Rad;
-                float rotation90 = rotation + Mathf.PI / 2;
                 Color32 color = particle.GetCurrentColor(pSystem);
                 float size = particle.GetCurrentSize(pSystem) * 0.5f;
 
@@ -280,13 +283,29 @@ namespace UnityEngine.UI.Extensions
                 _quad[3].color = color;
                 _quad[3].uv0 = temp;
 
+                
+                float rotation = -particle.rotation * Mathf.Deg2Rad;
+                var lengthScale = _lengthScale;
+                if (_useLengthScale) // this flag is mostly to secure old behaviour, it probably can be replaced with _lengthScale != 1
+                {
+                    // rotate towards velocity
+                    var normalizedVelocity = particle.velocity.normalized;
+                    rotation = Mathf.Atan2(normalizedVelocity.y, normalizedVelocity.x);
+                }
+                else
+                {
+                    lengthScale = 1f;
+                }
+                
+                float rotation90 = rotation + Mathf.PI / 2;
+
                 if (rotation == 0)
                 {
                     // no rotation
                     corner1.x = position.x - size;
-                    corner1.y = position.y - size;
+                    corner1.y = position.y - size * lengthScale;
                     corner2.x = position.x + size;
-                    corner2.y = position.y + size;
+                    corner2.y = position.y + size * lengthScale;
 
                     temp.x = corner1.x;
                     temp.y = corner1.y;
@@ -339,7 +358,7 @@ namespace UnityEngine.UI.Extensions
                     else
                     {
                         // apply rotation
-                        Vector2 right = new Vector2(Mathf.Cos(rotation), Mathf.Sin(rotation)) * size;
+                        Vector2 right = new Vector2(Mathf.Cos(rotation), Mathf.Sin(rotation)) * size * lengthScale;
                         Vector2 up = new Vector2(Mathf.Cos(rotation90), Mathf.Sin(rotation90)) * size;
 
                         _quad[0].position = position - right - up;


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->
UIParticleSystem did not replicate ParticleSystem's behaviour when Renderer.LengthScale was set to not 1

## Changes
<!-- Brief list of the targeted features that are being changed. -->
Add flag 'useLengthScale' to UIParticleSystem
Modify particle's quad computation to replicate lengthScale's behaviour

- Fixes: <!--issue number or url-->

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->
None

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
Tried changing Length Scale property of ParticleSystemRenderer while effect was played. Particles' length did not differ from standart ParticleSystem's.
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
