### PR TITLE
Fix Bug!NeicerOutline color.a Lose when m_UseGraphicAlpha is true!

### DIFF
--- a/.github/workflows/rununitybuildmultiversion.yml
+++ b/.github/workflows/rununitybuildmultiversion.yml
@@ -18,7 +18,7 @@ jobs:
           - os: windows
             unityVersion: 2019.4
             build-target: Android
-          - os: macos
+          - os: macOS
             unityVersion: 2019.4
             build-target: iOS
           - os: windows
@@ -30,7 +30,7 @@ jobs:
           - os: windows
             unityVersion: 2020.3
             build-target: Android
-          - os: macos
+          - os: macOS
             unityVersion: 2020.3
             build-target: iOS
           - os: windows
@@ -42,7 +42,7 @@ jobs:
           - os: windows
             unityVersion: 2021.3
             build-target: Android
-          - os: macos
+          - os: macOS
             unityVersion: 2021.3
             build-target: iOS
           - os: windows
@@ -54,7 +54,7 @@ jobs:
           - os: windows
             unityVersion: 2022.2
             build-target: Android
-          - os: macos
+          - os: macOS
             unityVersion: 2022.2
             build-target: iOS
           - os: windows
@@ -101,12 +101,12 @@ jobs:
           }
           elseif ( $global:PSVersionTable.OS.Contains("Darwin") ) 
           {
-            $hubPath = "/Applications/Unity Hub.app/Contents/MacOS/Unity Hub"
+            $hubPath = "/Applications/Unity Hub.app/Contents/macOS/Unity Hub"
             $editorRootPath = "/Applications/Unity/Hub/Editor/"
-            $editorFileEx = "/Unity.app/Contents/MacOS/Unity"
+            $editorFileEx = "/Unity.app/Contents/macOS/Unity"
             $directorySeparatorChar = "/"
 
-            # /Applications/Unity\ Hub.app/Contents/MacOS/Unity\ Hub -- --headless help
+            # /Applications/Unity\ Hub.app/Contents/macOS/Unity\ Hub -- --headless help
             function unity-hub 
             {
               & $hubPath -- --headless $args.Split(" ") | Out-String -NoNewline
@@ -218,7 +218,7 @@ jobs:
           }
           elseif ( $global:PSVersionTable.OS.Contains("Darwin") ) {
             echo 'Building using Mac'
-            $editorFileEx = "/Unity.app/Contents/MacOS/Unity"
+            $editorFileEx = "/Unity.app/Contents/macOS/Unity"
             $editorrunpath = Join-Path $editorRootPath $unityVersion $editorFileEx
 
             function unity-editor {

--- a/.github/workflows/rununitysinglebuild.yml
+++ b/.github/workflows/rununitysinglebuild.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos
+          - os: macOS
             build-target: iOS        
           - os: windows
             build-target: Android

--- a/Runtime/Scripts/Effects/NicerOutline.cs
+++ b/Runtime/Scripts/Effects/NicerOutline.cs
@@ -134,7 +134,7 @@ namespace UnityEngine.UI.Extensions
 			start += ApplyText(m_Verts, vh, start);
         }
         
-		private int ApplyOutlineNoGC(List<UIVertex> verts, Color color, float x, float y, VertexHelper vh, int startIndex)
+		private int ApplyOutlineNoGC(List<UIVertex> verts, Color32 color, float x, float y, VertexHelper vh, int startIndex)
 		{
 			int length = verts.Count;
 			for (int i = 0; i < length; ++i)


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
<!-- Please provide a clear and concise description of the pull request. -->

Runtime/Scripts/Effects/NicerOutline.cs:+137
if (m_UseGraphicAlpha)
    newColor.a = (byte)((newColor.a * verts[i].color.a) / 255);  //newColor's type cannot be Color.Should be Color32.


## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Fixes: 

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

- Breaks

## Related Submodule Changes

<!--  Include any submodule related Pull Request links here -->
- URL

## Testing status
<!-- Remove the options that do not apply -->

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
