### PR TITLE
Optimize Gradient2 when 'ModifyMesh' called

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.uiextensions",
   "displayName": "Unity UI Extensions",
-  "version": "2.3.2-pre.5",
+  "version": "2.3.2",
   "description": "An extension project for the Unity3D UI system, all crafted and contributed by the awesome Unity community",
   "author": "Simon darkside Jackson <@SimonDarksideJ>",
   "contributors": [


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
Gradient2 optimization

## Changes
Optimize Garbage when 'ModifyMesh' called, when target graphic's tint color changed or Gradient2 offset, zoom field changed.

- Fixes: #391
It may seems related to #391

## Breaking Changes
* Change List<T> and array constructor to pool rent call
* Change Default Sort method(DefaultArrayHelper) that generate garbage
* Cache field 'colorKeys' and 'alphaKeys' that generate garbage when every referece
* Some unity version support

## Related Submodule Changes
None

## Testing status
* No tests have been added.

### Manual testing status
https://github.com/bluefallsky/com.unity.uiextensions/tree/enhance/gradient2-optimize
sample scene path - WorkSpace/Gradient2/Gradient2Test.unity
For comparative testing, testing was conducted with Gradient2Optimize.cs