### PR TITLE
Add SetXWithoutNotify and SetYWithoutNotify to BoxSlider

### DIFF
--- a/Runtime/Scripts/Controls/Sliders/BoxSlider.cs
+++ b/Runtime/Scripts/Controls/Sliders/BoxSlider.cs
@@ -367,5 +367,14 @@ namespace UnityEngine.UI.Extensions
             eventData.useDragThreshold = false;
         }
 
+        public void SetXWithoutNotify(float x)
+        {
+            SetX(x, false);
+        }
+
+        public void SetYWithoutNotify(float y)
+        {
+            SetY(y, false);
+        }
     }
 }


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
Add `SetXWithoutNotify` and `SetYWithoutNotify` to BoxSlider. They set the X and Y values without invoking OnValueChanged.

## Changes
<!-- Brief list of the targeted features that are being changed. -->

- Fixes: <!--issue number or url-->

## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issue for existing projects? -->

- Breaks

## Related Submodule Changes

<!--  Include any submodule related Pull Request links here -->
- URL

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
I created a custom color picker and used BoxSlider as the Saturation Value slider.