### PR TITLE
Keep Item Rotation configuration.

### DIFF
--- a/Runtime/Scripts/Controls/ReorderableList/ReorderableList.cs
+++ b/Runtime/Scripts/Controls/ReorderableList/ReorderableList.cs
@@ -32,6 +32,9 @@ namespace UnityEngine.UI.Extensions
         [Tooltip("Should items being dragged over this list have their sizes equalized?")]
         public bool EqualizeSizesOnDrag = false;
 
+        [Tooltip("Should items keep the original rotation?")]
+        public bool KeepItemRotation = false;
+
         [Tooltip("Maximum number of items this container can hold")]
         public int maxItems = int.MaxValue;
 

--- a/Runtime/Scripts/Controls/ReorderableList/ReorderableListElement.cs
+++ b/Runtime/Scripts/Controls/ReorderableList/ReorderableListElement.cs
@@ -266,7 +266,10 @@ namespace UnityEngine.UI.Extensions
                 _displacedObjectLE.preferredWidth = _draggingObjectOriginalSize.x;
                 _displacedObjectLE.preferredHeight = _draggingObjectOriginalSize.y;
                 _displacedObject.SetParent(_reorderableList.Content, false);
-                _displacedObject.rotation = _reorderableList.transform.rotation;
+                if (!_reorderableList.KeepItemRotation)
+                {
+                    _displacedObject.rotation = _reorderableList.transform.rotation;
+                }
                 _displacedObject.SetSiblingIndex(_fromIndex);
                 // Force refreshing both lists because otherwise we get inappropriate FromList in ReorderableListEventStruct 
                 _reorderableList.Refresh();
@@ -310,7 +313,10 @@ namespace UnityEngine.UI.Extensions
             _displacedObjectLE.preferredWidth = _displacedObjectOriginalSize.x;
             _displacedObjectLE.preferredHeight = _displacedObjectOriginalSize.y;
             _displacedObject.SetParent(_displacedObjectOriginList.Content, false);
-            _displacedObject.rotation = _displacedObjectOriginList.transform.rotation;
+            if (!_reorderableList.KeepItemRotation)
+            {
+                _displacedObject.rotation = _displacedObjectOriginList.transform.rotation;
+            }
             _displacedObject.SetSiblingIndex(_displacedFromIndex);
             _displacedObject.gameObject.SetActive(true);
 
@@ -382,7 +388,10 @@ namespace UnityEngine.UI.Extensions
 
                     RefreshSizes();
                     _draggingObject.SetParent(_currentReorderableListRaycasted.Content, false);
-                    _draggingObject.rotation = _currentReorderableListRaycasted.transform.rotation;
+                    if (!_reorderableList.KeepItemRotation)
+                    {
+                        _draggingObject.rotation = _currentReorderableListRaycasted.transform.rotation;
+                    }
                     _draggingObject.SetSiblingIndex(_fakeElement.GetSiblingIndex());
 
                     //If the item is transferable, it can be dragged out again
@@ -474,7 +483,10 @@ namespace UnityEngine.UI.Extensions
             {
                 RefreshSizes();
                 _draggingObject.SetParent(_reorderableList.Content, false);
-                _draggingObject.rotation = _reorderableList.Content.transform.rotation;
+                if (!_reorderableList.KeepItemRotation)
+                {
+                    _draggingObject.rotation = _reorderableList.Content.transform.rotation;
+                }
                 _draggingObject.SetSiblingIndex(_fromIndex);
 
 


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
This PR aims to modify the `ReorderableList` by adding an option to keep dragged items' rotation. 

I'm using this `ReorderableList` to move some items from one list to another, but these items are Prefabs, some with some rotation specified. The issue is that when an item is dragged and dropped, it is taking the rotation of the list itself rather than the item's rotation. I guess it works fine for some items, but in my case, it's removing the Prefab's custom rotation. 

I'm new to Unity so I'm hoping I'm not doing anything wrong here, or breaking the purpose of this utility. 

## Changes
- A new option `keepItemRotation` is added as `false` by default.
- If the new option is marked (`true`) when an item is dropped, it will keep its rotation configuration. 



## Breaking Changes
<!--  Are there any breaking changes included in this change that would prevent or cause issues for existing projects? -->


## Related Submodule Changes

<!--  Include any submodule related Pull Request links here -->

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

I haven't found tests for this `ReorderableList`, so I might have missed them, if anyone can point me to them, I can try to add a test.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
I included my forked repository with changes in a Unity project and manually ran a few cases:
- Move an item from one list to another.
- Reorder an item inside a list.
- Activate the "clone" option and move a cloned object from one list to another.
- Move an item to a place where the drop is canceled and it returns to the original list.

<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->

I hope this is fine, let me know if anything :) 