### PR TITLE
UILineConnector point array calculation

### DIFF
--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -499,10 +499,6 @@ namespace UnityEngine.UI.Extensions
             {
 				m_points = new Vector2[1];
             }
-			if (transform.GetComponent<RectTransform>().position != Vector3.zero)
-			{
-				Debug.LogWarning("A Line Renderer component should be on a RectTransform positioned at (0,0,0), do not use in child Objects.\nFor best results, create separate RectTransforms as children of the canvas positioned at (0,0) for a UILineRenderer and do not move.");
-			}
         }
     }
 }


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
This PR modifies the `UILineConnector`'s implementation of calculating the point positions for `UILineRenderer`.


## Changes
- Fixes:
  - https://github.com/Unity-UI-Extensions/com.unity.uiextensions/issues/440
  - https://github.com/Unity-UI-Extensions/com.unity.uiextensions/issues/478

The new implementation directly converts `RectTransform[] transforms`'s world positions from `UILineConnector` to would-be local positions relative to `UILineRenderer`'s transform position.

```
Vector2[] points = new Vector2[transforms.Length];
for (int i = 0; i < transforms.Length; i++)
{
    if (transforms[i] == null)
    {
        continue;
    }
    var offsetPos = rt.InverseTransformPoint(transforms[i].position);
    points[i] = new Vector2(offsetPos.x, offsetPos.y);
}
```

This implementation also prevents UILineRenderer from using Relative Size:
```
if (lr.RelativeSize)
{
    Debug.LogWarning("While using UILineConnector, UILineRenderer should not use relative size, so that even if this RectTransform has a zero-size Rect, the positions of the points can still be calculated");
    lr.RelativeSize = false;
}
```

With this, when changing the pivot point of UILineRenderer's local RectTransform, the point array will be recalculated accordingly. The connector transforms will work regardless of placing them in a separate GO from the LineRenderer/Connector, or directly under as its children.

The new calculation thus fixes Issue#440, which also makes the warning in UILineRenderer become obsolete as well:

```
//(deleted in this PR)
if (transform.GetComponent<RectTransform>().position != Vector3.zero)
{
    Debug.LogWarning("A Line Renderer component should be on a RectTransform positioned at (0,0,0), do not use in child Objects.\nFor best results, create separate RectTransforms as children of the canvas positioned at (0,0) for a UILineRenderer and do not move.");
}
```


## Breaking Changes

## Related Submodule Changes

## Testing status
* No tests have been added.

### Manual testing status

I've tested with different GameObject hierarchy and different pivot points/anchor points configurations:
![image](https://github.com/user-attachments/assets/4d621a7c-e226-49ec-9a2b-7d62f55695a1)

My first PR ever, let me know if need further info.
