### PR TITLE
Hss/Vss force anchor setup

### DIFF
--- a/Runtime/Scripts/Controls/ReorderableList/ReorderableList.cs
+++ b/Runtime/Scripts/Controls/ReorderableList/ReorderableList.cs
@@ -32,6 +32,9 @@ namespace UnityEngine.UI.Extensions
         [Tooltip("Should items being dragged over this list have their sizes equalized?")]
         public bool EqualizeSizesOnDrag = false;
 
+        [Tooltip("Should items keep the original rotation?")]
+        public bool KeepItemRotation = false;
+
         [Tooltip("Maximum number of items this container can hold")]
         public int maxItems = int.MaxValue;
 

--- a/Runtime/Scripts/Controls/ReorderableList/ReorderableListElement.cs
+++ b/Runtime/Scripts/Controls/ReorderableList/ReorderableListElement.cs
@@ -266,7 +266,10 @@ namespace UnityEngine.UI.Extensions
                 _displacedObjectLE.preferredWidth = _draggingObjectOriginalSize.x;
                 _displacedObjectLE.preferredHeight = _draggingObjectOriginalSize.y;
                 _displacedObject.SetParent(_reorderableList.Content, false);
-                _displacedObject.rotation = _reorderableList.transform.rotation;
+                if (!_reorderableList.KeepItemRotation)
+                {
+                    _displacedObject.rotation = _reorderableList.transform.rotation;
+                }
                 _displacedObject.SetSiblingIndex(_fromIndex);
                 // Force refreshing both lists because otherwise we get inappropriate FromList in ReorderableListEventStruct 
                 _reorderableList.Refresh();
@@ -310,7 +313,10 @@ namespace UnityEngine.UI.Extensions
             _displacedObjectLE.preferredWidth = _displacedObjectOriginalSize.x;
             _displacedObjectLE.preferredHeight = _displacedObjectOriginalSize.y;
             _displacedObject.SetParent(_displacedObjectOriginList.Content, false);
-            _displacedObject.rotation = _displacedObjectOriginList.transform.rotation;
+            if (!_reorderableList.KeepItemRotation)
+            {
+                _displacedObject.rotation = _displacedObjectOriginList.transform.rotation;
+            }
             _displacedObject.SetSiblingIndex(_displacedFromIndex);
             _displacedObject.gameObject.SetActive(true);
 
@@ -382,7 +388,10 @@ namespace UnityEngine.UI.Extensions
 
                     RefreshSizes();
                     _draggingObject.SetParent(_currentReorderableListRaycasted.Content, false);
-                    _draggingObject.rotation = _currentReorderableListRaycasted.transform.rotation;
+                    if (!_reorderableList.KeepItemRotation)
+                    {
+                        _draggingObject.rotation = _currentReorderableListRaycasted.transform.rotation;
+                    }
                     _draggingObject.SetSiblingIndex(_fakeElement.GetSiblingIndex());
 
                     //If the item is transferable, it can be dragged out again
@@ -474,7 +483,10 @@ namespace UnityEngine.UI.Extensions
             {
                 RefreshSizes();
                 _draggingObject.SetParent(_reorderableList.Content, false);
-                _draggingObject.rotation = _reorderableList.Content.transform.rotation;
+                if (!_reorderableList.KeepItemRotation)
+                {
+                    _draggingObject.rotation = _reorderableList.Content.transform.rotation;
+                }
                 _draggingObject.SetSiblingIndex(_fromIndex);
 
 

--- a/Runtime/Scripts/Effects/Gradient2.cs
+++ b/Runtime/Scripts/Effects/Gradient2.cs
@@ -218,7 +218,7 @@ namespace UnityEngine.UI.Extensions
 
                             helper.AddVert(centralVertex);
 
-                            for (int i = 1; i < steps; i++) helper.AddTriangle(i - 1, i, steps);
+                            for (int i = 1; i < steps; i++) helper.AddTriangle(i, i-1, steps);
                             helper.AddTriangle(0, steps - 1, steps);
                         }
 

--- a/Runtime/Scripts/Layout/ScrollSnapBase.cs
+++ b/Runtime/Scripts/Layout/ScrollSnapBase.cs
@@ -189,6 +189,11 @@ namespace UnityEngine.UI.Extensions
 
             _screensContainer = _scroll_rect.content;
 
+            //ScrollRect.content RT anchors has to be stretched first in order for HSS/VSS.DistributePages() to have the correct result
+            _screensContainer.anchorMin = Vector2.zero;
+            _screensContainer.anchorMax = Vector2.one;
+            _screensContainer.sizeDelta = Vector2.zero;
+
             InitialiseChildObjects();
 
             if (NextButton)

--- a/Runtime/Scripts/Primitives/UILineRenderer.cs
+++ b/Runtime/Scripts/Primitives/UILineRenderer.cs
@@ -499,10 +499,6 @@ namespace UnityEngine.UI.Extensions
             {
 				m_points = new Vector2[1];
             }
-			if (transform.GetComponent<RectTransform>().position != Vector3.zero)
-			{
-				Debug.LogWarning("A Line Renderer component should be on a RectTransform positioned at (0,0,0), do not use in child Objects.\nFor best results, create separate RectTransforms as children of the canvas positioned at (0,0) for a UILineRenderer and do not move.");
-			}
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.uiextensions",
   "displayName": "Unity UI Extensions",
-  "version": "2.3.2-pre.5",
+  "version": "2.3.3",
   "description": "An extension project for the Unity3D UI system, all crafted and contributed by the awesome Unity community",
   "author": "Simon darkside Jackson <@SimonDarksideJ>",
   "contributors": [


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
Added a minor change in `ScrollSnapBase` to setup HSS/VSS properly in code.

## Changes
In order for HSS/VSS to work properly, the Content `RectTransform` under `ScrollRect` must have the anchors setup as stretched to the four corners and also has the same rect dimensions of its parent RT before `<HSS or VSS>.DistributePages()` is executed.

The added code forces these parameters in case they are not setup properly in Unity Inspector

inside `ScrollSnapBase.Awake()` :
```
_screensContainer = _scroll_rect.content;

//ScrollRect.content RT anchors has to be stretched first in order for HSS/VSS.DistributePages() to have the correct result
_screensContainer.anchorMin = Vector2.zero;
_screensContainer.anchorMax = Vector2.one;
_screensContainer.sizeDelta = Vector2.zero;
```


## Testing status
* No tests have been added.


### Manual testing status

