### PR TITLE
force ScrollRect.content setup [re-submission]

### DIFF
--- a/Runtime/Scripts/Layout/ScrollSnapBase.cs
+++ b/Runtime/Scripts/Layout/ScrollSnapBase.cs
@@ -189,6 +189,11 @@ namespace UnityEngine.UI.Extensions
 
             _screensContainer = _scroll_rect.content;
 
+            //ScrollRect.content RT anchors has to be stretched first in order for HSS/VSS.DistributePages() to have the correct result
+            _screensContainer.anchorMin = Vector2.zero;
+            _screensContainer.anchorMax = Vector2.one;
+            _screensContainer.sizeDelta = Vector2.zero;
+
             InitialiseChildObjects();
 
             if (NextButton)


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
**this is a resubmission of [PR#484](https://github.com/Unity-UI-Extensions/com.unity.uiextensions/pull/484)，re-targeting to development branch
Added a minor change in `ScrollSnapBase` to setup HSS/VSS properly in code.

## Changes
In order for HSS/VSS to work properly, the Content `RectTransform` under `ScrollRect` must have the anchors setup as stretched to the four corners and also has the same rect dimensions of its parent RT before `<HSS or VSS>.DistributePages()` is executed.

The added code forces these parameters in case they are not setup properly in Unity Inspector

inside `ScrollSnapBase.Awake()` :
```
_screensContainer = _scroll_rect.content;

//ScrollRect.content RT anchors has to be stretched first in order for HSS/VSS.DistributePages() to have the correct result
_screensContainer.anchorMin = Vector2.zero;
_screensContainer.anchorMax = Vector2.one;
_screensContainer.sizeDelta = Vector2.zero;
```


## Testing status
* No tests have been added.


### Manual testing status