### PR TITLE
Compile flag support for Unity6

### DIFF
--- a/Runtime/Scripts/Effects/Gradient2.cs
+++ b/Runtime/Scripts/Effects/Gradient2.cs
@@ -475,7 +475,7 @@ namespace UnityEngine.UI.Extensions
             var startBoundary = zoomOffset - offset;
             var endBoundary = (1 - zoomOffset) - offset;
 
-            if (_colorKeys == null) _colorKeys = EffectGradient.colorKeys;
+            _colorKeys = EffectGradient.colorKeys;
             
             foreach (var color in _colorKeys)
             {
@@ -485,7 +485,7 @@ namespace UnityEngine.UI.Extensions
                     stops.Add((color.time - startBoundary) * Zoom);
             }
 
-            if (_alphaKeys == null) _alphaKeys = _effectGradient.alphaKeys;
+            _alphaKeys = _effectGradient.alphaKeys;
             
             foreach (var alpha in _alphaKeys)
             {

--- a/Runtime/Scripts/Layout/CardUI/2D Cards/CardPopup2D.cs
+++ b/Runtime/Scripts/Layout/CardUI/2D Cards/CardPopup2D.cs
@@ -57,8 +57,12 @@ public class CardPopup2D : MonoBehaviour
         {
             isFalling = false;
             rbody.useGravity = false;
-            rbody.velocity = Vector3.zero;
-            transform.position = new Vector3(0, 8, startZPos);
+#if UNITY_6000_0_OR_NEWER
+                rbody.linearVelocity = Vector3.zero;
+#else
+                rbody.velocity = Vector3.zero;
+#endif
+                transform.position = new Vector3(0, 8, startZPos);
             if (singleScene)
             {
                 CardEnter();


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
Propose to start adding support for Unity 6. Version Compile Flags are used

## Changes
in `CardPopup2D.cs`, added compile flags regarding `Rigidbody` Component's velocity:

```
#if UNITY_6000_0_OR_NEWER
                rbody.linearVelocity = Vector3.zero;
#else
                rbody.velocity = Vector3.zero;
#endif
```