### PR TITLE
UILineConnector point array calculation

### DIFF
--- a/Runtime/Scripts/Utilities/UILineConnector.cs
+++ b/Runtime/Scripts/Utilities/UILineConnector.cs
@@ -54,7 +54,12 @@ namespace UnityEngine.UI.Extensions
             bool updateLine = lrWorldPos != previousLrPos;
             updateLine = rt.lossyScale != previousGlobalScale;
 
-            if (!updateLine && previousPositions != null && previousPositions.Length == transforms.Length)
+            if (!updateLine)
+            {
+                updateLine = previousPositions.Length != transforms.Length;
+            }
+
+            if (!updateLine && previousPositions != null)
             {
                 for (int i = 0; i < transforms.Length; i++)
                 {


### PR DESCRIPTION
# Unity UI Extensions - Pull Request

## Overview
In #480 the check for a change in length of transforms in a Line Connector was changed, resulting in the UILineRenderer not being updated when new points were added to the UILineConnector. This PR restores that check.

## Changes
Changed UILineConnector to CalculateLinePoints when the array size changes

- Fixes: #494 

## Breaking Changes

- None

## Related Submodule Changes

- None

## Testing status

* No tests have been added.

### Manual testing status

I've tested this both in an empty project with UI Extensions library in an empty scene, and in my working project that uses this setup to create an animation curve editor. 
