### PR TITLE
Fixed ColorPicker's precision not working

### DIFF
--- a/Runtime/Scripts/Controls/ColorPicker/ColorLabel.cs
+++ b/Runtime/Scripts/Controls/ColorPicker/ColorLabel.cs
@@ -72,7 +72,7 @@ namespace UnityEngine.UI.Extensions.ColorPicker
         private string ConvertToDisplayString(float value)
         {
             if (precision > 0)
-                return value.ToString("f " + precision);
+                return value.ToString("f" + precision);
             else
                 return Mathf.FloorToInt(value).ToString();
         }


### PR DESCRIPTION
As requested by @SimonDarksideJ in #528   I'm redoing this merge request but this time without the release branch's stuff - sorry about thatー

This MR fixes an issue with the precision for Color Picker's number values display.